### PR TITLE
Add DNS pollution protection for Clash

### DIFF
--- a/template/template/clash.tpl
+++ b/template/template/clash.tpl
@@ -6,9 +6,11 @@
 {% import './snippet/us_rules.tpl' as us_rules %}
 {% import './snippet/blocked_rules.tpl' as blocked_rules %}
 
-external-controller: 127.0.0.1:7892
+external-controller: 127.0.0.1:9090
 port: 7890
 socks-port: 7891
+redir-port: 7892
+
 
 Proxy: {{ getClashNodes(nodeList) | json }}
 

--- a/template/template/clash.tpl
+++ b/template/template/clash.tpl
@@ -11,6 +11,18 @@ port: 7890
 socks-port: 7891
 redir-port: 7892
 
+dns:
+  enable: true
+  nameserver:
+    - https://rubyfish.cn/dns-query
+  fallback:  # IP addresses who is outside CN in GEOIP will fallback here
+    - https://ea-dns.rubyfish.cn/dns-query
+    - https://1.0.0.1/dns-query
+    - https://dns.google/dns-query
+  fallback-filter:
+    geoip: true  # Enable GEOIP-based fallback
+    ipcidr:
+      - 240.0.0.0/4
 
 Proxy: {{ getClashNodes(nodeList) | json }}
 


### PR DESCRIPTION
This patch adds a couple of domestic and foreign DNS nameservers to prevent DNS pollution. 

The domestic nameservers may still be polluted, but their results are sufficient to distinguish domestic & foreign IPs.

In this configuration, it is possible to utilize DNS-over-TLS to maximize privacy and speed, while being resilient when in poor network condition (DOH as an alternative).

------

Also, this patch enables redir port by default which is required by Clash for Magisk.